### PR TITLE
Updating Purkinje-library - Package 6

### DIFF
--- a/example_configs/activation_time_and_apd_purkinje.ini
+++ b/example_configs/activation_time_and_apd_purkinje.ini
@@ -1,0 +1,62 @@
+# ====================================================================
+# Author: Lucas Berg
+# Description: This example demonstrate how to save the LAT and APD
+# maps in VTP format on a Purkinje-only simulation.
+# ====================================================================
+[main]
+num_threads=4
+dt_pde=0.02
+simulation_time=400.0
+abort_on_no_activity=false
+use_adaptivity=false
+
+[save_result]
+print_rate=1
+output_dir=./outputs/action_time_and_apd_purkinje
+save_pvd=true
+file_prefix=V
+save_activation_time=true
+save_apd=true
+library_file=shared_libs/libdefault_save_mesh_purkinje.so
+main_function=save_purkinje_with_activation_times
+init_function=init_save_purkinje_with_activation_times
+end_function=end_save_purkinje_with_activation_times
+remove_older_simulation=true
+
+[update_monodomain]
+main_function=update_monodomain_default
+
+[assembly_matrix]
+init_function=set_initial_conditions_fvm
+sigma_purkinje=0.0000176
+library_file=shared_libs/libpurkinje_matrix_assembly.so
+main_function=purkinje_fibers_assembly_matrix
+
+[linear_system_solver]
+tolerance=1e-16
+use_preconditioner=yes
+max_iterations=200
+library_file=shared_libs/libdefault_linear_system_solver.so
+main_function=conjugate_gradient
+
+[purkinje]
+name=Simple Purkinje
+dx=100.0
+library_file=shared_libs/libdefault_purkinje.so
+main_function=initialize_purkinje_with_custom_mesh
+network_file=networks/simple_cable_2cm.vtk
+
+[ode_solver]
+adaptive=true
+dt=0.01
+use_gpu=no
+gpu_id=0
+library_file=shared_libs/libstewart_aslanidi_noble_2009.so
+
+[purkinje_stim_his]
+start = 0.0
+duration = 2.0
+period = 1000.0
+current = -20.0
+id_limit = 5
+main_function=stim_if_id_less_than

--- a/example_configs/activation_time_and_apd_purkinje_coupling.ini
+++ b/example_configs/activation_time_and_apd_purkinje_coupling.ini
@@ -1,0 +1,100 @@
+# ==============================================================================
+# Author: Lucas Berg
+# Description: This simulation demonstrates how to save the LAT and APD
+# in a Purkinje-coupling experiment.
+# Features:
+#   - Cellular models: (Mitchell & Shaeffer[Tissue] + FHN[Purkinje])
+# ==============================================================================
+[main]
+num_threads=6
+dt_pde=0.02
+simulation_time=200.0
+abort_on_no_activity=false
+use_adaptivity=false
+
+[update_monodomain]
+main_function=update_monodomain_default
+
+[save_result]
+print_rate=1
+output_dir=./outputs/action_time_and_apd_purkinje_coupling
+activation_threshold_tissue=0.1
+activation_threshold_purkinje=0.1
+apd_threshold_tissue=0.1
+apd_threshold_purkinje=0.1
+save_activation_time=true
+save_apd=true
+save_pvd=true
+file_prefix=V_Tissue
+file_prefix_purkinje=V_Purkinje
+library_file=shared_libs/libdefault_save_mesh_purkinje.so
+main_function=save_purkinje_coupling_with_activation_times
+init_function=init_save_purkinje_coupling_with_activation_times
+end_function=end_save_purkinje_coupling_with_activation_times
+remove_older_simulation=true
+
+[assembly_matrix]
+init_function=set_initial_conditions_coupling_fvm
+sigma_x=0.0000176
+sigma_y=0.0001334
+sigma_z=0.0000176
+sigma_purkinje = 0.0006
+library_file=shared_libs/libpurkinje_coupling_matrix_assembly.so
+main_function=purkinje_coupling_assembly_matrix
+
+[linear_system_solver]
+tolerance=1e-16
+use_preconditioner=yes
+max_iterations=200
+library_file=shared_libs/libdefault_linear_system_solver.so
+main_function=conjugate_gradient
+
+[domain]
+name=Plain Mesh
+num_layers=1
+start_dx=100.0
+start_dy=100.0
+start_dz=100.0
+side_length=20000
+main_function=initialize_grid_with_square_mesh
+
+[ode_solver]
+dt=0.02
+use_gpu=yes
+gpu_id=0
+library_file=shared_libs/libmitchell_shaeffer_2003.so
+
+[purkinje]
+name=Benchmark Purkinje
+dx=100.0
+rpmj=100.0
+asymm_ratio=0.1 
+pmj_scale=500.0
+nmin_pmj=10
+nmax_pmj=50
+retro_propagation=true
+network_file=networks/benchmark_coupling_network.vtk
+library_file=shared_libs/libdefault_purkinje.so
+main_function=initialize_purkinje_coupling_with_custom_mesh
+
+[purkinje_ode_solver]
+dt=0.02
+use_gpu=no
+gpu_id=0
+library_file=shared_libs/libfhn_mod.so
+
+; Single beat
+[purkinje_stim_s1]
+start = 0.0
+duration = 2.0
+current = 1.0
+x_limit = -4500.0
+main_function=stim_if_x_less_than
+
+; Retro-propagation
+[stim_s2]
+start = 800.0
+duration = 2.0
+current = 1.0
+x_limit = 19500.0
+main_function=stim_if_x_greater_equal_than

--- a/src/config/save_mesh_config.h
+++ b/src/config/save_mesh_config.h
@@ -16,7 +16,7 @@ typedef SAVE_MESH(save_mesh_fn);
 #define INIT_SAVE_MESH(name)  void name(struct config *config)
 typedef INIT_SAVE_MESH(init_save_mesh_fn);
 
-#define END_SAVE_MESH(name)  void name(struct config *config)
+#define END_SAVE_MESH(name)  void name(struct config *config, struct grid *the_grid)
 typedef END_SAVE_MESH(end_save_mesh_fn);
 
 #define CALL_INIT_SAVE_MESH(config)                                                                                    \
@@ -26,10 +26,10 @@ typedef END_SAVE_MESH(end_save_mesh_fn);
         }                                                                                                              \
     } while(0)
 
-#define CALL_END_SAVE_MESH(config)                                                                                     \
+#define CALL_END_SAVE_MESH(config,grid)                                                                                     \
     do {                                                                                                               \
         if(config && config->end_function) {                                                                           \
-            ((end_save_mesh_fn *)config->end_function)(config);                                                        \
+            ((end_save_mesh_fn *)config->end_function)(config,grid);                                                        \
         }                                                                                                              \
     } while(0)
 

--- a/src/monodomain/monodomain_solver.c
+++ b/src/monodomain/monodomain_solver.c
@@ -574,12 +574,12 @@ int solve_monodomain(struct monodomain_solver *the_monodomain_solver, struct ode
                 gui_config.time = 0.0;
 
                 CALL_END_LINEAR_SYSTEM(linear_system_solver_config);
-                CALL_END_SAVE_MESH(save_mesh_config);
+                CALL_END_SAVE_MESH(save_mesh_config, the_grid);
                 return RESTART_SIMULATION;
             }
             if (gui_config.exit)  {
                 CALL_END_LINEAR_SYSTEM(linear_system_solver_config);
-                CALL_END_SAVE_MESH(save_mesh_config);
+                CALL_END_SAVE_MESH(save_mesh_config, the_grid);
                 return END_SIMULATION;
             }
         }
@@ -811,7 +811,7 @@ int solve_monodomain(struct monodomain_solver *the_monodomain_solver, struct ode
                         CALL_END_LINEAR_SYSTEM(linear_system_solver_config);
                         CALL_INIT_LINEAR_SYSTEM(linear_system_solver_config, the_grid);
 
-						CALL_END_SAVE_MESH(save_mesh_config);
+						CALL_END_SAVE_MESH(save_mesh_config, the_grid);
 						CALL_INIT_SAVE_MESH(save_mesh_config);
 
                         shput_dup_value(dconfig->config_data, "modification_applied", "true");
@@ -870,6 +870,7 @@ int solve_monodomain(struct monodomain_solver *the_monodomain_solver, struct ode
     }
 
     if (purkinje_config && domain_config) {
+        print_pmj_delay(the_grid,save_mesh_config,the_terminals);
         free_terminals(the_terminals,the_grid->purkinje->network->number_of_terminals);
     }
 
@@ -887,7 +888,7 @@ int solve_monodomain(struct monodomain_solver *the_monodomain_solver, struct ode
 #endif
 
     CALL_END_LINEAR_SYSTEM(linear_system_solver_config);
-    CALL_END_SAVE_MESH(save_mesh_config);
+    CALL_END_SAVE_MESH(save_mesh_config, the_grid);
 
     return SIMULATION_FINISHED;
 
@@ -1440,4 +1441,12 @@ void compute_pmj_current_tissue_to_purkinje (struct ode_solver *the_purkinje_ode
 
         }
     }
+}
+
+void print_pmj_delay (struct grid *the_grid, struct config *config, struct terminal *the_terminals) {
+    assert(the_grid);
+    assert(config);
+    assert(the_terminals);
+
+    log_to_stdout_and_file("Print PMJ delay!\n");
 }

--- a/src/monodomain/monodomain_solver.h
+++ b/src/monodomain/monodomain_solver.h
@@ -60,6 +60,7 @@ bool update_ode_state_vector_and_check_for_activity(real_cpu vm_threshold, struc
 void compute_pmj_current_purkinje_to_tissue (struct ode_solver *the_ode_solver, struct grid *the_grid, struct terminal *the_terminals);
 void compute_pmj_current_tissue_to_purkinje (struct ode_solver *the_purkinje_ode_solver, struct grid *the_grid, struct terminal *the_terminals);
 
+void print_pmj_delay (struct grid *the_grid, struct config *config, struct terminal *the_terminals);
 
 void debug_print_and_leave ();
 

--- a/src/save_mesh_library/build.sh
+++ b/src/save_mesh_library/build.sh
@@ -8,4 +8,4 @@ fi
 
 COMPILE_SHARED_LIB "default_save_mesh" "save_mesh.c" "" "$SAVE_STATIC_DEPS" "$SAVE_DYNAMIC_DEPS" "$CUDA_LIBRARY_PATH"
 
-COMPILE_SHARED_LIB "default_save_mesh_purkinje" "save_mesh_purkinje.c" "" "$SAVE_STATIC_DEPS" "$SAVE_DYNAMIC_DEPS" "$CUDA_LIBRARY_PATH"
+COMPILE_SHARED_LIB "default_save_mesh_purkinje" "save_mesh_purkinje.c save_mesh_helper.c" "save_mesh_helper.h" "$SAVE_STATIC_DEPS" "$SAVE_DYNAMIC_DEPS" "$CUDA_LIBRARY_PATH"

--- a/src/save_mesh_library/save_mesh_helper.c
+++ b/src/save_mesh_library/save_mesh_helper.c
@@ -1,0 +1,715 @@
+#include "save_mesh_helper.h"
+
+inline void write_pvd_header(FILE *pvd_file) {
+    fprintf(pvd_file, "<VTKFile type=\"Collection\" version=\"0.1\" compressor=\"vtkZLibDataCompressor\">\n");
+    fprintf(pvd_file, "\t<Collection>\n");
+    fprintf(pvd_file, "\t</Collection>\n");
+    fprintf(pvd_file, "</VTKFile>");
+}
+
+sds create_base_name(char *f_prefix, int iteration_count, char *extension) {
+    return sdscatprintf(sdsempty(), "%s_it_%d.%s", f_prefix, iteration_count, extension);
+}
+
+void add_file_to_pvd(real_cpu current_t, const char *output_dir, const char *base_name, bool first_call) {
+
+    sds pvd_name = sdsnew(output_dir);
+    pvd_name = sdscat(pvd_name, "/simulation_result.pvd");
+
+    static FILE *pvd_file = NULL;
+    pvd_file = fopen(pvd_name, "r+");
+
+    if(!pvd_file) {
+        pvd_file = fopen(pvd_name, "w");
+        write_pvd_header(pvd_file);
+    }
+    else {
+        if(first_call) {
+            fclose(pvd_file);
+            pvd_file = fopen(pvd_name, "w");
+            write_pvd_header(pvd_file);
+        }
+    }
+
+    sdsfree(pvd_name);
+
+    fseek(pvd_file, -26, SEEK_END);
+
+    fprintf(pvd_file, "\n\t\t<DataSet timestep=\"%lf\" group=\"\" part=\"0\" file=\"%s\"/>\n", current_t, base_name);
+    fprintf(pvd_file, "\t</Collection>\n");
+    fprintf(pvd_file, "</VTKFile>");
+    fclose(pvd_file);
+}
+
+void calculate_purkinje_activation_time_and_apd (struct time_info *time_info, struct config *config, struct grid *the_grid, const real_cpu time_threshold,\
+                                            const real_cpu purkinje_activation_threshold, const real_cpu purkinje_apd_threshold) {
+
+    real_cpu current_t = time_info->current_t;
+    real_cpu last_t = time_info->final_t;
+    real_cpu dt = time_info->dt;
+
+    struct save_coupling_with_activation_times_persistent_data *persistent_data =
+            (struct save_coupling_with_activation_times_persistent_data*)config->persistent_data;
+
+    struct cell_node *purkinje_grid_cell = the_grid->purkinje->first_cell;
+
+    real_cpu center_x, center_y, center_z;
+    real_cpu v;
+
+    while(purkinje_grid_cell != 0) {
+
+        if( purkinje_grid_cell->active || ( purkinje_grid_cell->mesh_extra_info && ( FIBROTIC(purkinje_grid_cell) || BORDER_ZONE(purkinje_grid_cell) ) ) ) {
+
+            center_x = purkinje_grid_cell->center.x;
+            center_y = purkinje_grid_cell->center.y;
+            center_z = purkinje_grid_cell->center.z;
+
+            v = purkinje_grid_cell->v;
+
+            struct point_3d cell_coordinates;
+            cell_coordinates.x = center_x;
+            cell_coordinates.y = center_y;
+            cell_coordinates.z = center_z;
+
+            int n_activations = 0;
+            float *apds_array = NULL;
+            float *activation_times_array = NULL;
+
+            if(purkinje_grid_cell->active) {
+
+                float last_v = hmget(persistent_data->purkinje_last_time_v, cell_coordinates);
+
+                n_activations = (int) hmget(persistent_data->purkinje_num_activations, cell_coordinates);
+                activation_times_array = (float *) hmget(persistent_data->purkinje_activation_times, cell_coordinates);
+                apds_array = (float *) hmget(persistent_data->purkinje_apds, cell_coordinates);
+
+                int act_times_len = arrlen(activation_times_array);
+
+                if (current_t == 0.0f) {
+                    hmput(persistent_data->purkinje_last_time_v, cell_coordinates, v);
+                } else {
+                    if ((last_v < purkinje_activation_threshold) && (v >= purkinje_activation_threshold)) {
+
+                        if (act_times_len == 0) {
+                            n_activations++;
+                            hmput(persistent_data->purkinje_num_activations, cell_coordinates, n_activations);
+                            arrput(activation_times_array, current_t);
+                            float tmp = hmget(persistent_data->purkinje_cell_was_active, cell_coordinates);
+                            hmput(persistent_data->purkinje_cell_was_active, cell_coordinates, tmp + 1);
+                            hmput(persistent_data->purkinje_activation_times, cell_coordinates, activation_times_array);
+                        } else { //This is to avoid spikes in the middle of an Action Potential
+                            float last_act_time = activation_times_array[act_times_len - 1];
+                            if (current_t - last_act_time > time_threshold) {
+                                n_activations++;
+                                hmput(persistent_data->purkinje_num_activations, cell_coordinates, n_activations);
+                                arrput(activation_times_array, current_t);
+                                float tmp = hmget(persistent_data->purkinje_cell_was_active, cell_coordinates);
+                                hmput(persistent_data->purkinje_cell_was_active, cell_coordinates, tmp + 1);
+                                hmput(persistent_data->purkinje_activation_times, cell_coordinates, activation_times_array);
+                            }
+                        }
+                    }
+
+                    //CHECK APD
+                    bool was_active = (hmget(persistent_data->purkinje_cell_was_active, cell_coordinates) != 0.0);
+                    if (was_active) {
+                        if (v <= purkinje_apd_threshold || (hmget(persistent_data->purkinje_cell_was_active, cell_coordinates) == 2.0) || (last_t-current_t) <= dt) {
+
+                            int tmp = (int)hmget(persistent_data->purkinje_cell_was_active, cell_coordinates);
+                            int act_time_array_len = arrlen(activation_times_array);
+                            //if this in being calculated because we had a new activation before the cell achieved the rest potential,
+                            // we need to get the activation before this one
+                            real_cpu last_act_time = activation_times_array[act_time_array_len  - tmp];
+                            real_cpu apd = current_t - last_act_time;
+                            arrput(apds_array, apd);
+                            hmput(persistent_data->purkinje_apds, cell_coordinates, apds_array);
+                            hmput(persistent_data->purkinje_cell_was_active, cell_coordinates, tmp - 1);
+                        }
+                    }
+
+                    hmput(persistent_data->purkinje_last_time_v, cell_coordinates, v);
+                }
+            }
+        }
+        purkinje_grid_cell = purkinje_grid_cell->next;
+    }
+
+}
+
+void write_purkinje_activation_time_maps (struct config *config, struct grid *the_grid, char *output_dir,\
+                                    char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                                    bool save_pvd, bool compress, int compression_level) {
+
+    if(((struct save_coupling_with_activation_times_persistent_data*) config->persistent_data)->first_save_call) {
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(output_dir, config->config_data, "output_dir");
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(file_prefix, config->config_data, "file_prefix");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_plain, config->config_data, "clip_with_plain");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_bounds, config->config_data, "clip_with_bounds");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(binary, config->config_data, "binary");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(save_pvd, config->config_data, "save_pvd");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(compress, config->config_data, "compress");
+        GET_PARAMETER_NUMERIC_VALUE_OR_USE_DEFAULT(int, compression_level, config->config_data, "compression_level");
+
+        if(compress) binary = true;
+
+        if(!save_pvd) {
+            ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->first_save_call = false;
+        }
+    }
+
+    float plain_coords[6] = {0, 0, 0, 0, 0, 0};
+    float bounds[6] = {0, 0, 0, 0, 0, 0};
+
+    if(clip_with_plain) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[0], config->config_data, "origin_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[1], config->config_data, "origin_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[2], config->config_data, "origin_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[3], config->config_data, "normal_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[4], config->config_data, "normal_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[5], config->config_data, "normal_z");
+    }
+
+    if(clip_with_bounds) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[0], config->config_data, "min_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[1], config->config_data, "min_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[2], config->config_data, "min_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[3], config->config_data, "max_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[4], config->config_data, "max_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[5], config->config_data, "max_z");
+    }
+
+    write_purkinje_activation_time_for_each_pulse(config,the_grid,output_dir,plain_coords,bounds,clip_with_plain,clip_with_bounds,binary,save_pvd,compress,compression_level);
+
+}
+
+void write_purkinje_activation_time_for_each_pulse (struct config *config, struct grid *the_grid,\
+                                            char *output_dir, float plain_coords[], float bounds[],\
+                                            bool clip_with_plain, bool clip_with_bounds, bool binary, bool save_pvd, bool compress, int compression_level) {
+
+    struct save_coupling_with_activation_times_persistent_data **data = (struct save_coupling_with_activation_times_persistent_data **)&config->persistent_data;
+
+    struct cell_node **grid_cell = the_grid->purkinje->purkinje_cells;
+
+    real_cpu center_x, center_y, center_z;
+
+    center_x = grid_cell[0]->center.x;
+    center_y = grid_cell[0]->center.y;
+    center_z = grid_cell[0]->center.z;
+
+    struct point_3d cell_coordinates;
+    cell_coordinates.x = center_x;
+    cell_coordinates.y = center_y;
+    cell_coordinates.z = center_z;
+
+    // Get the number of pulses using one cell of the grid
+    int n_pulses = (int) hmget((*data)->purkinje_num_activations, cell_coordinates);
+
+    // Write the activation time map for each pulse
+    for (int cur_pulse = 0; cur_pulse < n_pulses; cur_pulse++) {
+
+        sds base_name = create_base_name("purkinje_activation_time_map_pulse", cur_pulse, "vtp");
+        sds output_dir_with_file = sdsnew(output_dir);
+        output_dir_with_file = sdscat(output_dir_with_file, "/");
+        output_dir_with_file = sdscatprintf(output_dir_with_file, base_name, cur_pulse);
+
+        bool read_only_data = ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid != NULL;
+        new_vtk_polydata_grid_from_purkinje_grid(&((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid, the_grid->purkinje, clip_with_plain, plain_coords, clip_with_bounds, bounds, read_only_data);
+
+        set_purkinje_vtk_values_with_activation_time_from_current_pulse(&config->persistent_data,the_grid,cur_pulse);
+
+        if(compress) {
+            save_vtk_polydata_grid_as_vtp_compressed(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid, output_dir_with_file, compression_level);
+        }
+        else {
+            save_vtk_polydata_grid_as_vtp(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid, output_dir_with_file, binary);
+        }
+
+        free_vtk_polydata_grid(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid);
+        ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid = NULL;
+
+        sdsfree(output_dir_with_file);
+        sdsfree(base_name);        
+    }    
+
+}
+
+void set_purkinje_vtk_values_with_activation_time_from_current_pulse (void **persistent_data, struct grid *the_grid, const int cur_pulse) {
+
+    struct save_coupling_with_activation_times_persistent_data **data = (struct save_coupling_with_activation_times_persistent_data **)persistent_data;
+
+    struct cell_node **purkinje_grid_cell = the_grid->purkinje->purkinje_cells;
+    uint32_t num_active_cells =  the_grid->purkinje->num_active_purkinje_cells;
+
+    real_cpu center_x, center_y, center_z;
+
+    // We need to pass through the cells in the same order as we did when the VTU grid was created
+    for(int i = 0; i < num_active_cells; i++) {
+
+        center_x = purkinje_grid_cell[i]->center.x;
+        center_y = purkinje_grid_cell[i]->center.y;
+        center_z = purkinje_grid_cell[i]->center.z;
+
+        struct point_3d cell_coordinates;
+        cell_coordinates.x = center_x;
+        cell_coordinates.y = center_y;
+        cell_coordinates.z = center_z;
+
+        float *activation_times_array = NULL;
+
+        if(purkinje_grid_cell[i]->active) {
+
+            activation_times_array = (float *) hmget((*data)->purkinje_activation_times, cell_coordinates);
+
+            // Get the activation time from the current pulse for that particular cell
+            float at = activation_times_array[cur_pulse];           
+
+            // Update the scalar value from the "vtk_unstructured_grid"
+            (*data)->purkinje_grid->values[i] = at;
+
+        }      
+    }    
+}
+
+void write_purkinje_apd_map (struct config *config, struct grid *the_grid, char *output_dir,\
+                        char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                        bool save_pvd, bool compress, int compression_level) {
+
+    real_cpu current_t = 0.0;
+
+    if(((struct save_coupling_with_activation_times_persistent_data*) config->persistent_data)->first_save_call) {
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(output_dir, config->config_data, "output_dir");
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(file_prefix, config->config_data, "file_prefix");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_plain, config->config_data, "clip_with_plain");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_bounds, config->config_data, "clip_with_bounds");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(binary, config->config_data, "binary");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(save_pvd, config->config_data, "save_pvd");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(compress, config->config_data, "compress");
+        GET_PARAMETER_NUMERIC_VALUE_OR_USE_DEFAULT(int, compression_level, config->config_data, "compression_level");
+
+        if(compress) binary = true;
+
+        if(!save_pvd) {
+            ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->first_save_call = false;
+        }
+    }
+
+    float plain_coords[6] = {0, 0, 0, 0, 0, 0};
+    float bounds[6] = {0, 0, 0, 0, 0, 0};
+
+    if(clip_with_plain) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[0], config->config_data, "origin_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[1], config->config_data, "origin_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[2], config->config_data, "origin_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[3], config->config_data, "normal_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[4], config->config_data, "normal_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[5], config->config_data, "normal_z");
+    }
+
+    if(clip_with_bounds) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[0], config->config_data, "min_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[1], config->config_data, "min_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[2], config->config_data, "min_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[3], config->config_data, "max_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[4], config->config_data, "max_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[5], config->config_data, "max_z");
+    }
+
+    sds base_name = create_base_name("purkinje_apd_map", 0, "vtp");
+    sds output_dir_with_file = sdsnew(output_dir);
+    output_dir_with_file = sdscat(output_dir_with_file, "/");
+    output_dir_with_file = sdscatprintf(output_dir_with_file, base_name, current_t);
+
+    bool read_only_data = ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid != NULL;
+    new_vtk_polydata_grid_from_purkinje_grid(&((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid, the_grid->purkinje, clip_with_plain, plain_coords, clip_with_bounds, bounds, read_only_data);
+
+    set_purkinje_vtk_values_with_mean_apd(&config->persistent_data,the_grid);
+
+    if(compress) {
+        save_vtk_polydata_grid_as_vtp_compressed(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid, output_dir_with_file, compression_level);
+    }
+    else {
+        save_vtk_polydata_grid_as_vtp(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid, output_dir_with_file, binary);
+    }
+
+    free_vtk_polydata_grid(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid);
+    ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->purkinje_grid = NULL;
+
+    sdsfree(output_dir_with_file);
+    sdsfree(base_name);
+}
+
+void set_purkinje_vtk_values_with_mean_apd (void **persistent_data, struct grid *the_grid)
+{
+    struct save_coupling_with_activation_times_persistent_data **data = (struct save_coupling_with_activation_times_persistent_data **)persistent_data;
+
+    struct cell_node **purkinje_grid_cell = the_grid->purkinje->purkinje_cells;
+    uint32_t num_active_cells =  the_grid->purkinje->num_active_purkinje_cells;
+
+    real_cpu center_x, center_y, center_z;
+
+    // We need to pass through the cells in the same order as we did when the VTU grid was created
+    for(int i = 0; i < num_active_cells; i++) {
+
+        center_x = purkinje_grid_cell[i]->center.x;
+        center_y = purkinje_grid_cell[i]->center.y;
+        center_z = purkinje_grid_cell[i]->center.z;
+
+        struct point_3d cell_coordinates;
+        cell_coordinates.x = center_x;
+        cell_coordinates.y = center_y;
+        cell_coordinates.z = center_z;
+
+        float *apds_array = NULL;
+
+        if(purkinje_grid_cell[i]->active) {
+
+            apds_array = (float *) hmget((*data)->purkinje_apds, cell_coordinates);
+
+            unsigned long apd_len = arrlen(apds_array);
+
+            // Calculate the mean APD values
+            float mean_value = 0.0;
+            mean_value = calculate_mean(apds_array,apd_len);
+            
+            // Update the scalar value from the "vtk_unstructured_grid"
+            (*data)->purkinje_grid->values[i] = mean_value;
+
+        }      
+    }    
+}
+
+void calculate_tissue_activation_time_and_apd (struct time_info *time_info, struct config *config, struct grid *the_grid, const real_cpu time_threshold,\
+                                            const real_cpu tissue_activation_threshold, const real_cpu tissue_apd_threshold) {
+
+    real_cpu current_t = time_info->current_t;
+    real_cpu last_t = time_info->final_t;
+    real_cpu dt = time_info->dt;
+
+    struct save_coupling_with_activation_times_persistent_data *persistent_data =
+            (struct save_coupling_with_activation_times_persistent_data*)config->persistent_data;
+
+    struct cell_node *tissue_grid_cell = the_grid->first_cell;
+
+    real_cpu center_x, center_y, center_z;
+    real_cpu v;
+
+    while(tissue_grid_cell != 0) {
+
+        if( tissue_grid_cell->active || ( tissue_grid_cell->mesh_extra_info && ( FIBROTIC(tissue_grid_cell) || BORDER_ZONE(tissue_grid_cell) ) ) ) {
+            
+            center_x = tissue_grid_cell->center.x;
+            center_y = tissue_grid_cell->center.y;
+            center_z = tissue_grid_cell->center.z;
+
+            v = tissue_grid_cell->v;
+
+            struct point_3d cell_coordinates;
+            cell_coordinates.x = center_x;
+            cell_coordinates.y = center_y;
+            cell_coordinates.z = center_z;
+
+            int n_activations = 0;
+            float *apds_array = NULL;
+            float *activation_times_array = NULL;
+
+            if(tissue_grid_cell->active) {
+
+                float last_v = hmget(persistent_data->tissue_last_time_v, cell_coordinates);
+
+                n_activations = (int) hmget(persistent_data->tissue_num_activations, cell_coordinates);
+                activation_times_array = (float *) hmget(persistent_data->tissue_activation_times, cell_coordinates);
+                apds_array = (float *) hmget(persistent_data->tissue_apds, cell_coordinates);
+
+                int act_times_len = arrlen(activation_times_array);
+
+                if (current_t == 0.0f) {
+                    hmput(persistent_data->tissue_last_time_v, cell_coordinates, v);
+                } else {
+                    if ((last_v < tissue_activation_threshold) && (v >= tissue_activation_threshold)) {
+
+                        if (act_times_len == 0) {
+                            n_activations++;
+                            hmput(persistent_data->tissue_num_activations, cell_coordinates, n_activations);
+                            arrput(activation_times_array, current_t);
+                            float tmp = hmget(persistent_data->tissue_cell_was_active, cell_coordinates);
+                            hmput(persistent_data->tissue_cell_was_active, cell_coordinates, tmp + 1);
+                            hmput(persistent_data->tissue_activation_times, cell_coordinates, activation_times_array);
+                        } else { //This is to avoid spikes in the middle of an Action Potential
+                            float last_act_time = activation_times_array[act_times_len - 1];
+                            if (current_t - last_act_time > time_threshold) {
+                                n_activations++;
+                                hmput(persistent_data->tissue_num_activations, cell_coordinates, n_activations);
+                                arrput(activation_times_array, current_t);
+                                float tmp = hmget(persistent_data->tissue_cell_was_active, cell_coordinates);
+                                hmput(persistent_data->tissue_cell_was_active, cell_coordinates, tmp + 1);
+                                hmput(persistent_data->tissue_activation_times, cell_coordinates, activation_times_array);
+                            }
+                        }
+                    }
+
+                    //CHECK APD
+                    bool was_active = (hmget(persistent_data->tissue_cell_was_active, cell_coordinates) != 0.0);
+                    if (was_active) {
+                        if (v <= tissue_apd_threshold || (hmget(persistent_data->tissue_cell_was_active, cell_coordinates) == 2.0) || (last_t-current_t) <= dt) {
+
+                            int tmp = (int)hmget(persistent_data->tissue_cell_was_active, cell_coordinates);
+                            int act_time_array_len = arrlen(activation_times_array);
+                            //if this in being calculated because we had a new activation before the cell achieved the rest potential,
+                            // we need to get the activation before this one
+                            real_cpu last_act_time = activation_times_array[act_time_array_len  - tmp];
+                            real_cpu apd = current_t - last_act_time;
+                            arrput(apds_array, apd);
+                            hmput(persistent_data->tissue_apds, cell_coordinates, apds_array);
+                            hmput(persistent_data->tissue_cell_was_active, cell_coordinates, tmp - 1);
+                        }
+                    }
+
+                    hmput(persistent_data->tissue_last_time_v, cell_coordinates, v);
+                }
+            }
+        }
+        tissue_grid_cell = tissue_grid_cell->next;
+    }
+}
+
+void write_tissue_apd_map (struct config *config, struct grid *the_grid, char *output_dir,\
+                                    char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                                    bool save_pvd, bool compress, int compression_level, bool save_f) {
+
+    real_cpu current_t = 0.0;
+
+    if(((struct save_coupling_with_activation_times_persistent_data*) config->persistent_data)->first_save_call) {
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(output_dir, config->config_data, "output_dir");
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(file_prefix, config->config_data, "file_prefix");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_plain, config->config_data, "clip_with_plain");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_bounds, config->config_data, "clip_with_bounds");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(binary, config->config_data, "binary");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(save_pvd, config->config_data, "save_pvd");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(compress, config->config_data, "compress");
+        GET_PARAMETER_NUMERIC_VALUE_OR_USE_DEFAULT(int, compression_level, config->config_data, "compression_level");
+
+        if(compress) binary = true;
+
+        if(!save_pvd) {
+            ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->first_save_call = false;
+        }
+    }
+
+    float plain_coords[6] = {0, 0, 0, 0, 0, 0};
+    float bounds[6] = {0, 0, 0, 0, 0, 0};
+
+    if(clip_with_plain) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[0], config->config_data, "origin_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[1], config->config_data, "origin_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[2], config->config_data, "origin_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[3], config->config_data, "normal_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[4], config->config_data, "normal_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[5], config->config_data, "normal_z");
+    }
+
+    if(clip_with_bounds) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[0], config->config_data, "min_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[1], config->config_data, "min_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[2], config->config_data, "min_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[3], config->config_data, "max_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[4], config->config_data, "max_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[5], config->config_data, "max_z");
+    }
+
+    sds base_name = create_base_name("tissue_apd_map", 0, "vtu");
+    sds output_dir_with_file = sdsnew(output_dir);
+    output_dir_with_file = sdscat(output_dir_with_file, "/");
+    output_dir_with_file = sdscatprintf(output_dir_with_file, base_name, current_t);
+
+    bool read_only_data = ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid != NULL;
+    new_vtk_unstructured_grid_from_alg_grid(&((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid, the_grid, clip_with_plain, plain_coords, clip_with_bounds, bounds, read_only_data, save_f);
+
+    set_tissue_vtk_values_with_mean_apd(&config->persistent_data,the_grid);
+
+    if(compress) {
+        save_vtk_unstructured_grid_as_vtu_compressed(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid, output_dir_with_file, compression_level);
+    }
+    else {
+        save_vtk_unstructured_grid_as_vtu(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid, output_dir_with_file, binary);
+    }
+
+    free_vtk_unstructured_grid(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid);
+    ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid = NULL;
+
+    sdsfree(output_dir_with_file);
+    sdsfree(base_name);
+}
+
+void write_tissue_activation_time_maps (struct config *config, struct grid *the_grid, char *output_dir,\
+                                    char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                                    bool save_pvd, bool compress, int compression_level, bool save_f) {
+
+    if(((struct save_coupling_with_activation_times_persistent_data*) config->persistent_data)->first_save_call) {
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(output_dir, config->config_data, "output_dir");
+        GET_PARAMETER_STRING_VALUE_OR_REPORT_ERROR(file_prefix, config->config_data, "file_prefix");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_plain, config->config_data, "clip_with_plain");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(clip_with_bounds, config->config_data, "clip_with_bounds");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(binary, config->config_data, "binary");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(save_pvd, config->config_data, "save_pvd");
+        GET_PARAMETER_BOOLEAN_VALUE_OR_USE_DEFAULT(compress, config->config_data, "compress");
+        GET_PARAMETER_NUMERIC_VALUE_OR_USE_DEFAULT(int, compression_level, config->config_data, "compression_level");
+
+        if(compress) binary = true;
+
+        if(!save_pvd) {
+            ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->first_save_call = false;
+        }
+    }
+
+    float plain_coords[6] = {0, 0, 0, 0, 0, 0};
+    float bounds[6] = {0, 0, 0, 0, 0, 0};
+
+    if(clip_with_plain) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[0], config->config_data, "origin_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[1], config->config_data, "origin_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[2], config->config_data, "origin_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[3], config->config_data, "normal_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[4], config->config_data, "normal_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, plain_coords[5], config->config_data, "normal_z");
+    }
+
+    if(clip_with_bounds) {
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[0], config->config_data, "min_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[1], config->config_data, "min_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[2], config->config_data, "min_z");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[3], config->config_data, "max_x");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[4], config->config_data, "max_y");
+        GET_PARAMETER_NUMERIC_VALUE_OR_REPORT_ERROR(float, bounds[5], config->config_data, "max_z");
+    }
+
+    write_tissue_activation_time_for_each_pulse(config,the_grid,output_dir,plain_coords,bounds,clip_with_plain,clip_with_bounds,binary,save_pvd,compress,compression_level,save_f);
+
+}
+
+void write_tissue_activation_time_for_each_pulse (struct config *config, struct grid *the_grid,\
+                                            char *output_dir, float plain_coords[], float bounds[],\
+                                            bool clip_with_plain, bool clip_with_bounds, bool binary, bool save_pvd, bool compress, int compression_level, bool save_f) {
+
+    struct save_coupling_with_activation_times_persistent_data **data = (struct save_coupling_with_activation_times_persistent_data **)&config->persistent_data;
+
+    struct cell_node **grid_cell = the_grid->active_cells;
+
+    real_cpu center_x, center_y, center_z;
+
+    center_x = grid_cell[0]->center.x;
+    center_y = grid_cell[0]->center.y;
+    center_z = grid_cell[0]->center.z;
+
+    struct point_3d cell_coordinates;
+    cell_coordinates.x = center_x;
+    cell_coordinates.y = center_y;
+    cell_coordinates.z = center_z;
+
+    // Get the number of pulses using one cell of the grid
+    int n_pulses = (int) hmget((*data)->tissue_num_activations, cell_coordinates);
+    
+    // Write the activation time map for each pulse
+    for (int cur_pulse = 0; cur_pulse < n_pulses; cur_pulse++) {
+
+        sds base_name = create_base_name("tissue_activation_time_map_pulse", cur_pulse, "vtu");
+        sds output_dir_with_file = sdsnew(output_dir);
+        output_dir_with_file = sdscat(output_dir_with_file, "/");
+        output_dir_with_file = sdscatprintf(output_dir_with_file, base_name, cur_pulse);
+
+        bool read_only_data = ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid != NULL;
+        new_vtk_unstructured_grid_from_alg_grid(&((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid, the_grid, clip_with_plain, plain_coords, clip_with_bounds, bounds, read_only_data, save_f);
+
+        set_tissue_vtk_values_with_activation_time_from_current_pulse(&config->persistent_data,the_grid,cur_pulse);
+
+        if(compress) {
+            save_vtk_unstructured_grid_as_vtu_compressed(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid, output_dir_with_file, compression_level);
+        }
+        else {
+            save_vtk_unstructured_grid_as_vtu(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid, output_dir_with_file, binary);
+        }
+
+        free_vtk_unstructured_grid(((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid);
+        ((struct save_coupling_with_activation_times_persistent_data *) config->persistent_data)->tissue_grid = NULL;
+
+        sdsfree(output_dir_with_file);
+        sdsfree(base_name);        
+    }    
+}
+
+void set_tissue_vtk_values_with_activation_time_from_current_pulse (void **persistent_data, struct grid *the_grid, const int cur_pulse) {
+
+    struct save_coupling_with_activation_times_persistent_data **data = (struct save_coupling_with_activation_times_persistent_data **)persistent_data;
+
+    struct cell_node **grid_cell = the_grid->active_cells;
+    uint32_t num_active_cells =  the_grid->num_active_cells;
+
+    real_cpu center_x, center_y, center_z;
+
+    // We need to pass through the cells in the same order as we did when the VTU grid was created
+    for(int i = 0; i < num_active_cells; i++) {
+
+        center_x = grid_cell[i]->center.x;
+        center_y = grid_cell[i]->center.y;
+        center_z = grid_cell[i]->center.z;
+
+        struct point_3d cell_coordinates;
+        cell_coordinates.x = center_x;
+        cell_coordinates.y = center_y;
+        cell_coordinates.z = center_z;
+
+        float *activation_times_array = NULL;
+
+        if(grid_cell[i]->active) {
+
+            activation_times_array = (float *) hmget((*data)->tissue_activation_times, cell_coordinates);
+
+            // TODO: Check the case where: (activation_times_array == NULL)
+            // Get the activation time from the current pulse for that particular cell
+            float at = activation_times_array[cur_pulse];           
+
+            // Update the scalar value from the "vtk_unstructured_grid"
+            (*data)->tissue_grid->values[i] = at;
+
+        }      
+    }    
+}
+
+void set_tissue_vtk_values_with_mean_apd (void **persistent_data, struct grid *the_grid) {
+
+    struct save_coupling_with_activation_times_persistent_data **data = (struct save_coupling_with_activation_times_persistent_data **)persistent_data;
+
+    struct cell_node **grid_cell = the_grid->active_cells;
+    uint32_t num_active_cells =  the_grid->num_active_cells;
+
+    real_cpu center_x, center_y, center_z;
+
+    // We need to pass through the cells in the same order as we did when the VTU grid was created
+    for(int i = 0; i < num_active_cells; i++) {
+
+        center_x = grid_cell[i]->center.x;
+        center_y = grid_cell[i]->center.y;
+        center_z = grid_cell[i]->center.z;
+
+        struct point_3d cell_coordinates;
+        cell_coordinates.x = center_x;
+        cell_coordinates.y = center_y;
+        cell_coordinates.z = center_z;
+
+        float *apds_array = NULL;
+
+        if(grid_cell[i]->active) {
+
+            apds_array = (float *) hmget((*data)->tissue_apds, cell_coordinates);
+
+            unsigned long apd_len = arrlen(apds_array);
+
+            // Calculate the mean APD values
+            float mean_value = 0.0;
+            mean_value = calculate_mean(apds_array,apd_len);
+            
+            // Update the scalar value from the "vtk_unstructured_grid"
+            (*data)->tissue_grid->values[i] = mean_value;
+
+        }      
+    }    
+}

--- a/src/save_mesh_library/save_mesh_helper.h
+++ b/src/save_mesh_library/save_mesh_helper.h
@@ -1,0 +1,86 @@
+//
+// Created by bergolho on 02/10/20.
+//
+
+#ifndef MONOALG3D_SAVE_MESH_HELPERS_H
+#define MONOALG3D_SAVE_MESH_HELPERS_H
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "../3dparty/sds/sds.h"
+#include "../alg/grid/grid.h"
+#include "../config/save_mesh_config.h"
+#include "../utils/utils.h"
+
+#include "../vtk_utils/vtk_unstructured_grid.h"
+#include "../vtk_utils/vtk_polydata_grid.h"
+#include "../libraries_common/common_data_structures.h"
+
+struct save_as_vtp_persistent_data {
+    struct vtk_polydata_grid *grid;
+    bool first_save_call;
+};
+
+struct save_tissue_as_vtu_purkinje_as_vtp_persistent_data {
+    struct vtk_unstructured_grid *grid;
+    struct vtk_polydata_grid *grid_purkinje;
+    bool first_save_call;
+};
+
+struct save_coupling_with_activation_times_persistent_data {
+
+    struct vtk_unstructured_grid *tissue_grid;
+    struct point_hash_entry *tissue_last_time_v;
+    struct point_hash_entry *tissue_num_activations;
+    struct point_hash_entry *tissue_cell_was_active;
+    struct point_voidp_hash_entry *tissue_activation_times;
+    struct point_voidp_hash_entry *tissue_apds;
+
+    struct vtk_polydata_grid *purkinje_grid;
+    struct point_hash_entry *purkinje_last_time_v;
+    struct point_hash_entry *purkinje_num_activations;
+    struct point_hash_entry *purkinje_cell_was_active;
+    struct point_voidp_hash_entry *purkinje_activation_times;
+    struct point_voidp_hash_entry *purkinje_apds;
+
+    bool first_save_call;
+
+};
+
+void add_file_to_pvd(real_cpu current_t, const char *output_dir, const char *base_name, bool first_save_call);
+sds create_base_name(char *f_prefix, int iteration_count, char *extension);
+
+// [PURKINJE]
+void calculate_purkinje_activation_time_and_apd (struct time_info *time_info, struct config *config, struct grid *the_grid, const real_cpu time_threshold,\
+                                            const real_cpu purkinje_activation_threshold, const real_cpu purkinje_apd_threshold);
+void write_purkinje_activation_time_maps (struct config *config, struct grid *the_grid, char *output_dir,\
+                                    char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                                    bool save_pvd, bool compress, int compression_level);
+void write_purkinje_activation_time_for_each_pulse (struct config *config, struct grid *the_grid,\
+                                            char *output_dir, float plain_coords[], float bounds[],\
+                                            bool clip_with_plain, bool clip_with_bounds, bool binary, bool save_pvd, bool compress, int compression_level);
+void write_purkinje_apd_map (struct config *config, struct grid *the_grid, char *output_dir,\
+                        char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                        bool save_pvd, bool compress, int compression_level);
+void set_purkinje_vtk_values_with_activation_time_from_current_pulse (void **persistent_data, struct grid *the_grid, const int cur_pulse);
+void set_purkinje_vtk_values_with_mean_apd (void **persistent_data, struct grid *the_grid);
+
+// [TISSUE]
+void calculate_tissue_activation_time_and_apd (struct time_info *time_info, struct config *config, struct grid *the_grid, const real_cpu time_threshold,\
+                                            const real_cpu tissue_activation_threshold, const real_cpu tissue_apd_threshold);
+void write_tissue_activation_time_maps (struct config *config, struct grid *the_grid, char *output_dir,\
+                                    char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                                    bool save_pvd, bool compress, int compression_level, bool save_f);
+void write_tissue_activation_time_for_each_pulse (struct config *config, struct grid *the_grid,\
+                                    char *output_dir, float plain_coords[], float bounds[],\
+                                    bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                                    bool save_pvd, bool compress, int compression_level, bool save_f);
+void write_tissue_apd_map (struct config *config, struct grid *the_grid, char *output_dir,\
+                                    char *file_prefix, bool clip_with_plain, bool clip_with_bounds, bool binary,\
+                                    bool save_pvd, bool compress, int compression_level, bool save_f);
+void set_tissue_vtk_values_with_mean_apd (void **persistent_data, struct grid *the_grid);
+void set_tissue_vtk_values_with_activation_time_from_current_pulse (void **persistent_data, struct grid *the_grid, const int cur_pulse);
+
+#endif

--- a/src/utils/search.c
+++ b/src/utils/search.c
@@ -70,3 +70,10 @@ int inside_mesh(real_cpu **a, real_cpu x, real_cpu y, real_cpu z, int first, int
 
     }
 }
+
+float calculate_mean (float *arr, unsigned long size) {
+    float result = 0.0;
+    for (unsigned long i = 0; i < size; i++)
+        result += arr[i];
+    return result/(float)size;
+}

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -11,5 +11,6 @@
 
 void sort_vector(real_cpu **a, int length);
 int inside_mesh(real_cpu **a, real_cpu x, real_cpu y, real_cpu z, int first, int last);
+float calculate_mean (float *arr, unsigned long size);
 
 #endif //MONOALG3D_UTILS_H_H


### PR DESCRIPTION
Hello Sachetto,

In this pull request, I included the functions to save the LAT and APD maps in VTP/VTU format. Also, I stored all the functions and structures that are not: INIT_SAVE_MESH, END_SAVE_MESH or SAVE_MESH in a helper library ("save_mesh_helper") to reduce ammount of code in the "save_mesh_purkinje.c". This way the "libdefault_save_mesh_purkinje.so" will only have the initialization, termination and main function on its scope. Just to mention that I did not do this to the "save_mesh.c" file, but you can follow this pattern if you find suitable. The PMJ delay function is not ready yet and needs further testing.