### PR TITLE
Fixed minor error in ToRORd model files

### DIFF
--- a/src/models_library/ToROrd/ToRORd_dynCl_mixed_endo_mid_epi.c
+++ b/src/models_library/ToROrd/ToRORd_dynCl_mixed_endo_mid_epi.c
@@ -145,11 +145,11 @@ SOLVE_MODEL_ODES(solve_model_odes_cpu) {
         extra_par[7]  = extra_data->IKb_Multiplier; 
         extra_par[8]  = extra_data->INaCa_Multiplier;
         extra_par[9]  = extra_data->INaK_Multiplier;  
-        extra_par[9]  = extra_data->INab_Multiplier;  
-        extra_par[10] = extra_data->ICab_Multiplier;  
-        extra_par[11] = extra_data->IpCa_Multiplier;  
-        extra_par[12] = extra_data->ICaCl_Multiplier;
-        extra_par[13] = extra_data->IClb_Multiplier; 
+        extra_par[10]  = extra_data->INab_Multiplier;  
+        extra_par[11] = extra_data->ICab_Multiplier;  
+        extra_par[12] = extra_data->IpCa_Multiplier;  
+        extra_par[13] = extra_data->ICaCl_Multiplier;
+        extra_par[14] = extra_data->IClb_Multiplier; 
         extra_par[15] = extra_data->Jrel_Multiplier; 
         extra_par[16] = extra_data->Jup_Multiplier;
         transmurality = extra_data->transmurality;
@@ -165,11 +165,11 @@ SOLVE_MODEL_ODES(solve_model_odes_cpu) {
         extra_par[7]  = 1.0; 
         extra_par[8]  = 1.0;
         extra_par[9]  = 1.0;
-        extra_par[9]  = 1.0; 
         extra_par[10] = 1.0;  
         extra_par[11] = 1.0; 
         extra_par[12] = 1.0;
         extra_par[13] = 1.0;
+        extra_par[14] = 1.0; 
         extra_par[15] = 1.0;
         extra_par[16] = 1.0;
     }

--- a/src/models_library/ToROrd/ToRORd_dynCl_mixed_endo_mid_epi.cu
+++ b/src/models_library/ToROrd/ToRORd_dynCl_mixed_endo_mid_epi.cu
@@ -206,11 +206,11 @@ extern "C" SOLVE_MODEL_ODES(solve_model_odes_gpu) {
         extra_par[7]  = extra_data->IKb_Multiplier; 
         extra_par[8]  = extra_data->INaCa_Multiplier;
         extra_par[9]  = extra_data->INaK_Multiplier;  
-        extra_par[9]  = extra_data->INab_Multiplier;  
-        extra_par[10] = extra_data->ICab_Multiplier;  
-        extra_par[11] = extra_data->IpCa_Multiplier;  
-        extra_par[12] = extra_data->ICaCl_Multiplier;
-        extra_par[13] = extra_data->IClb_Multiplier; 
+        extra_par[10]  = extra_data->INab_Multiplier;  
+        extra_par[11] = extra_data->ICab_Multiplier;  
+        extra_par[12] = extra_data->IpCa_Multiplier;  
+        extra_par[13] = extra_data->ICaCl_Multiplier;
+        extra_par[14] = extra_data->IClb_Multiplier; 
         extra_par[15] = extra_data->Jrel_Multiplier; 
         extra_par[16] = extra_data->Jup_Multiplier;
         transmurality = extra_data->transmurality;
@@ -232,11 +232,11 @@ extern "C" SOLVE_MODEL_ODES(solve_model_odes_gpu) {
         extra_par[7]  = 1.0; 
         extra_par[8]  = 1.0;
         extra_par[9]  = 1.0;
-        extra_par[9]  = 1.0; 
         extra_par[10] = 1.0;  
         extra_par[11] = 1.0; 
         extra_par[12] = 1.0;
         extra_par[13] = 1.0;
+        extra_par[14] = 1.0;
         extra_par[15] = 1.0;
         extra_par[16] = 1.0;
 

--- a/src/models_library/ToROrd/ToRORd_fkatp_mixed_endo_mid_epi.c
+++ b/src/models_library/ToROrd/ToRORd_fkatp_mixed_endo_mid_epi.c
@@ -189,11 +189,11 @@ SOLVE_MODEL_ODES(solve_model_odes_cpu) {
         extra_par[7]  = extra_data->IKb_Multiplier; 
         extra_par[8]  = extra_data->INaCa_Multiplier;
         extra_par[9]  = extra_data->INaK_Multiplier;  
-        extra_par[9]  = extra_data->INab_Multiplier;  
-        extra_par[10] = extra_data->ICab_Multiplier;  
-        extra_par[11] = extra_data->IpCa_Multiplier;  
-        extra_par[12] = extra_data->ICaCl_Multiplier;
-        extra_par[13] = extra_data->IClb_Multiplier; 
+        extra_par[10]  = extra_data->INab_Multiplier;  
+        extra_par[11] = extra_data->ICab_Multiplier;  
+        extra_par[12] = extra_data->IpCa_Multiplier;  
+        extra_par[13] = extra_data->ICaCl_Multiplier;
+        extra_par[14] = extra_data->IClb_Multiplier; 
         extra_par[15] = extra_data->Jrel_Multiplier; 
         extra_par[16] = extra_data->Jup_Multiplier;
         transmurality = extra_data->transmurality;
@@ -209,11 +209,11 @@ SOLVE_MODEL_ODES(solve_model_odes_cpu) {
         extra_par[7]  = 1.0; 
         extra_par[8]  = 1.0;
         extra_par[9]  = 1.0;
-        extra_par[9]  = 1.0; 
         extra_par[10] = 1.0;  
         extra_par[11] = 1.0; 
         extra_par[12] = 1.0;
         extra_par[13] = 1.0;
+        extra_par[14] = 1.0;
         extra_par[15] = 1.0;
         extra_par[16] = 1.0;
     }

--- a/src/models_library/ToROrd/ToRORd_fkatp_mixed_endo_mid_epi.cu
+++ b/src/models_library/ToROrd/ToRORd_fkatp_mixed_endo_mid_epi.cu
@@ -251,11 +251,11 @@ extern "C" SOLVE_MODEL_ODES(solve_model_odes_gpu) {
         extra_par[7]  = extra_data->IKb_Multiplier; 
         extra_par[8]  = extra_data->INaCa_Multiplier;
         extra_par[9]  = extra_data->INaK_Multiplier;  
-        extra_par[9]  = extra_data->INab_Multiplier;  
-        extra_par[10] = extra_data->ICab_Multiplier;  
-        extra_par[11] = extra_data->IpCa_Multiplier;  
-        extra_par[12] = extra_data->ICaCl_Multiplier;
-        extra_par[13] = extra_data->IClb_Multiplier; 
+        extra_par[10]  = extra_data->INab_Multiplier;  
+        extra_par[11] = extra_data->ICab_Multiplier;  
+        extra_par[12] = extra_data->IpCa_Multiplier;  
+        extra_par[13] = extra_data->ICaCl_Multiplier;
+        extra_par[14] = extra_data->IClb_Multiplier; 
         extra_par[15] = extra_data->Jrel_Multiplier; 
         extra_par[16] = extra_data->Jup_Multiplier;
         transmurality = extra_data->transmurality;
@@ -277,11 +277,11 @@ extern "C" SOLVE_MODEL_ODES(solve_model_odes_gpu) {
         extra_par[7]  = 1.0; 
         extra_par[8]  = 1.0;
         extra_par[9]  = 1.0;
-        extra_par[9]  = 1.0; 
         extra_par[10] = 1.0;  
         extra_par[11] = 1.0; 
         extra_par[12] = 1.0;
         extra_par[13] = 1.0;
+        extra_par[14] = 1.0;
         extra_par[15] = 1.0;
         extra_par[16] = 1.0;
 


### PR DESCRIPTION
Fixed a minor indexing error in ToRORd model implementation (dynCl and fkatp versions). The sequence of indices in SOLVE_MODEL_ODES function contained a duplicate index value (9) where a sequential increment was expected, and was missing index value 14. This has now been corrected in the files below, where the inconsistency was spotted. No further changes were made. Thanks for maintaining the repo!

Files changed:
ToRORd_dynCl_mixed_endo_mid_epi.cu
ToRORd_dynCl_mixed_endo_mid_epi.c
ToRORd_fkatp_mixed_endo_mid_epi.c
ToRORd_fkatp_mixed_endo_mid_epi.cu